### PR TITLE
Last Day Typo in Doku and in Source File

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Die folgenden Konfigurationsparameter sind für die Quelle verfügbar:
 Innerhalb des Shell-Scriptes stehen die folgenden Umgebnugsvariablen zur Verfügung:
 
 * `FIRST_DAY` - Der erste Tag, für den der Zählerstand benötigt wird. Format: `2023-01-19`
-* `FIRST_DAY` - Der letzte Tag, für den der Zählerstand benötigt wird. Format: `2023-01-22`
+* `LAST_DAY` - Der letzte Tag, für den der Zählerstand benötigt wird. Format: `2023-01-22`
 * `METER` - Die abgefragte Zähelernummer. Format: `1EBZ0123456789`
 * `FIRST_DAY_START_ISO_TZ` - Die Startzeit des ersten Tages, Format: `2023-01-19T00:00:00+01:00[Europe/Berlin]`
 * `LAST_DAY_END_ISO_TZ` - Die Startzeit des Folgetages des letzten Tages. Format: `2023-01-23T00:00:00+01:00[Europe/Berlin]`

--- a/src/main/java/de/wyraz/tibberuploader/source/ScriptedRestApiMeterReadingSource.java
+++ b/src/main/java/de/wyraz/tibberuploader/source/ScriptedRestApiMeterReadingSource.java
@@ -24,7 +24,7 @@ import de.wyraz.tibberuploader.TibberConstants;
  * 
  * Provided environment variables:
  *   FIRST_DAY - the first day to query in the format 2023-01-19
- *   LAST_DAY - the first day to query in the format 2023-01-22
+ *   LAST_DAY - the last day to query in the format 2023-01-22
  *   METER - the meter that is being queried in the format 1EBZ0123456789
  *   FIRST_DAY_START_ISO_TZ - the start time of first day to query in ISO format with local time zone, e.g. 2023-01-19T00:00:00+01:00[Europe/Berlin]
  *   LAST_DAY_END_ISO_TZ - the start time of the day after the last day to query in ISO format with local time zone, e.g. 2023-01-23T00:00:00+01:00[Europe/Berlin]
@@ -74,7 +74,7 @@ public class ScriptedRestApiMeterReadingSource implements IMeterReadingSource {
 		
 		Map<String, String> env=new HashMap<>();
 		env.put("FIRST_DAY", firstDay.toString());
-		env.put("LAST_DAY", firstDay.toString());
+		env.put("LAST_DAY", lastDay.toString());
 		env.put("METER", meterNumber);
 		env.put("FIRST_DAY_START_ISO_TZ", firstDay.atStartOfDay(TibberConstants.TIMEZONE_ID).toString());
 		env.put("LAST_DAY_END_ISO_TZ", lastDay.plusDays(1).atStartOfDay(TibberConstants.TIMEZONE_ID).toString());


### PR DESCRIPTION
Hello,

in the Doku you have e little Typo with FIRST_DAY and LAST_DAY and in the Source Code you habe LAST_DAY defined with FIRST Day data.